### PR TITLE
feat: Add Redis/Valkey-backed template store

### DIFF
--- a/src/Service/GenerateFromSavedTemplateInput.cs
+++ b/src/Service/GenerateFromSavedTemplateInput.cs
@@ -1,0 +1,3 @@
+namespace Service;
+
+internal record GenerateFromSavedTemplateInput(string Key, string Model);

--- a/src/Service/GenerateInput.cs
+++ b/src/Service/GenerateInput.cs
@@ -1,0 +1,3 @@
+namespace Service;
+
+internal record GenerateInput(string Template, string Model);

--- a/src/Service/Handlers.cs
+++ b/src/Service/Handlers.cs
@@ -1,0 +1,41 @@
+namespace Service;
+
+using System.Text;
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Distributed;
+
+using Scriban;
+
+internal static class Handlers
+{
+    internal static string Generate([FromBody] GenerateInput input)
+    {
+        Template? template = Template.Parse(input.Template);
+        object data = (object?)JsonSerializer.Deserialize<JsonElement>(input.Model) ?? new { };
+        string result = template?.Render(data, member => $"{char.ToLower(member.Name[0])}{member.Name[1..]}") ?? string.Empty;
+        return result;
+    }
+
+    internal static async Task<string> GenerateFromSavedTemplateAsync(
+        [FromBody] GenerateFromSavedTemplateInput input,
+        [FromServices] IDistributedCache cache,
+        CancellationToken cancellationToken
+    )
+    {
+        byte[] data = await cache.GetAsync(input.Key, cancellationToken).ConfigureAwait(false) ?? [];
+
+        string template = Encoding.UTF8.GetString(data);
+
+        return Generate(new GenerateInput(template, input.Model));
+    }
+
+    internal static Task SaveTemplateAsync(
+        [FromBody] TemplateSaveInput input,
+        [FromServices] IDistributedCache cache,
+        CancellationToken cancellationToken)
+    {
+        return cache.SetStringAsync(input.Key, input.Template, cancellationToken);
+    }
+}

--- a/src/Service/Program.cs
+++ b/src/Service/Program.cs
@@ -1,32 +1,11 @@
-using System.Text.Json;
-
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.OpenApi;
-
-using Scriban;
+using Service;
 
 AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromSeconds(2));
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddOpenApi("v1",
-    options => { options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0; });
+builder.ConfigureServices();
 
 WebApplication app = builder.Build();
-
-app.MapOpenApi("/openapi.json").CacheOutput();
-
-app.MapGet("/generate", Generate).WithDescription("Generates a string from a model and a template").WithTags("template");
+app.ConfigureRouting();
 
 await app.RunAsync();
-return;
-
-static string Generate([FromBody] GenerateInput input, CancellationToken cancellationToken)
-{
-    Template? template = Template.Parse(input.Template);
-    object data = (object?)JsonSerializer.Deserialize<JsonElement>(input.Model) ?? new { };
-    string result = template?.Render(data, member => $"{char.ToLower(member.Name[0])}{member.Name[1..]}") ?? string.Empty;
-    return result;
-}
-
-internal record GenerateInput(string Template, string Model);

--- a/src/Service/ProgramConfiguration.Logging.cs
+++ b/src/Service/ProgramConfiguration.Logging.cs
@@ -1,0 +1,22 @@
+namespace Service;
+
+using OpenTelemetry.Resources;
+
+using Serilog;
+using Serilog.Core;
+
+internal static partial class ProgramConfiguration
+{
+    private static Action<ILoggingBuilder> ConfigureLogging(IConfiguration configuration, string serviceName)
+    {
+        return Configure;
+
+        void Configure(ILoggingBuilder loggingBuilder)
+        {
+            Logger serilog = new LoggerConfiguration().ReadFrom.Configuration(configuration).CreateLogger();
+            loggingBuilder.AddSerilog(serilog);
+
+            loggingBuilder.AddOpenTelemetry(options => { options.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService(serviceName)); });
+        }
+    }
+}

--- a/src/Service/ProgramConfiguration.OpenApi.cs
+++ b/src/Service/ProgramConfiguration.OpenApi.cs
@@ -1,0 +1,12 @@
+namespace Service;
+
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+
+internal static partial class ProgramConfiguration
+{
+    private static void ConfigureOpenApi(OpenApiOptions options)
+    {
+        options.OpenApiVersion = OpenApiSpecVersion.OpenApi3_0;
+    }
+}

--- a/src/Service/ProgramConfiguration.OpenTelemetry.cs
+++ b/src/Service/ProgramConfiguration.OpenTelemetry.cs
@@ -1,0 +1,54 @@
+namespace Service;
+
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+internal static partial class ProgramConfiguration
+{
+    private static Action<MeterProviderBuilder> ConfigureMetrics(string serviceName)
+    {
+        return Configure;
+
+        void Configure(MeterProviderBuilder meterProviderBuilder)
+        {
+            meterProviderBuilder.AddMeter(serviceName);
+        }
+    }
+
+    private static Action<ResourceBuilder> ConfigureResource(string serviceName, string serviceVersion)
+    {
+        return Configure;
+
+        void Configure(ResourceBuilder resourceBuilder)
+        {
+            resourceBuilder.AddService(serviceName, serviceVersion);
+        }
+    }
+
+    private static Action<TracerProviderBuilder> ConfigureTracing(
+        IConfiguration configuration,
+        string serviceName)
+    {
+        return Configure;
+
+        void Configure(TracerProviderBuilder tracerProviderBuilder)
+        {
+            tracerProviderBuilder.AddSource(serviceName)
+                .AddAspNetCoreInstrumentation()
+                .AddRedisInstrumentation();
+
+            tracerProviderBuilder.AddOtlpExporter(options =>
+            {
+                options.Protocol = OtlpExportProtocol.HttpProtobuf;
+                options.Endpoint = new Uri(configuration["otlpEndpoint"] ?? throw new InvalidOperationException("missing otlp uri"));
+            });
+
+            if (configuration["ASPNETCORE_ENVIRONMENT"] == "Development")
+            {
+                tracerProviderBuilder.AddConsoleExporter();
+            }
+        }
+    }
+}

--- a/src/Service/ProgramConfiguration.Routing.cs
+++ b/src/Service/ProgramConfiguration.Routing.cs
@@ -1,0 +1,20 @@
+namespace Service;
+
+using Prometheus;
+
+internal static partial class ProgramConfiguration
+{
+    public static partial void ConfigureRouting(this WebApplication app)
+    {
+        app.MapOpenApi("/openapi.json").CacheOutput();
+        app.MapHealthChecks("/healthz");
+        app.MapMetrics("/metricsz");
+        
+        app.MapGet("/generate", Handlers.Generate).WithDescription("Generates a string from a model and a template").WithTags("template");
+
+        app.MapPost("/template", Handlers.SaveTemplateAsync).WithDescription("Saves a template").WithTags("template");
+
+        app.MapGet("/generateFromSavedTemplate", Handlers.GenerateFromSavedTemplateAsync).WithDescription("Generates a string from a model and a saved template")
+            .WithTags("template");
+    }
+}

--- a/src/Service/ProgramConfiguration.Services.cs
+++ b/src/Service/ProgramConfiguration.Services.cs
@@ -1,0 +1,26 @@
+namespace Service;
+
+using Prometheus;
+
+internal static partial class ProgramConfiguration
+{
+    public static partial void ConfigureServices(this WebApplicationBuilder builder)
+    {
+        string serviceName = builder.Configuration["serviceName"]!;
+        string serviceVersion = builder.Configuration["serviceVersion"] ?? "0.0.1";
+
+        builder.Services.AddOpenApi("v1", ConfigureOpenApi);
+
+        builder.Services.AddStackExchangeRedisCache(ConfigureValkey(builder.Configuration["valkey"]));
+
+        builder.Services.AddMetrics();
+        builder.Services.AddHealthChecks().ForwardToPrometheus();
+
+        builder.Services.AddLogging(ConfigureLogging(builder.Configuration, serviceName));
+
+        builder.Services.AddOpenTelemetry()
+            .ConfigureResource(ConfigureResource(serviceName, serviceVersion))
+            .WithTracing(ConfigureTracing(builder.Configuration, serviceName))
+            .WithMetrics(ConfigureMetrics(serviceName));
+    }
+}

--- a/src/Service/ProgramConfiguration.Valkey.cs
+++ b/src/Service/ProgramConfiguration.Valkey.cs
@@ -1,0 +1,16 @@
+namespace Service;
+
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+
+internal static partial class ProgramConfiguration
+{
+    private static Action<RedisCacheOptions> ConfigureValkey(string? configuration)
+    {
+        return Configure;
+
+        void Configure(RedisCacheOptions options)
+        {
+            options.Configuration = configuration;
+        }
+    }
+}

--- a/src/Service/ProgramConfiguration.cs
+++ b/src/Service/ProgramConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Service;
+
+internal static partial class ProgramConfiguration
+{
+    public static partial void ConfigureRouting(this WebApplication app);
+    public static partial void ConfigureServices(this WebApplicationBuilder builder);
+}

--- a/src/Service/Service.csproj
+++ b/src/Service/Service.csproj
@@ -22,8 +22,25 @@
   </Choose>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.Prometheus.Metrics" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Redis" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.4" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.11.0-beta.2" />
+    <PackageReference Include="prometheus-net.AspNetCore.HealthChecks" Version="8.2.1" />
     <PackageReference Include="Scriban.Signed" Version="6.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="10.8.0.113526">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StackExchange.Redis" Version="2.8.24" />
   </ItemGroup>
 
 </Project>

--- a/src/Service/TemplateSaveInput.cs
+++ b/src/Service/TemplateSaveInput.cs
@@ -1,0 +1,3 @@
+namespace Service;
+
+internal record TemplateSaveInput(string Key, string Template);

--- a/src/Service/appsettings.Development.json
+++ b/src/Service/appsettings.Development.json
@@ -1,8 +1,44 @@
 {
-  "Logging": {
-    "LogLevel": {
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Grafana.Loki",
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
+      "Override": {
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      },
+      {
+        "Name": "GrafanaLoki",
+        "Args": {
+          "uri": "http://localhost:3100",
+          "labels": [
+            {
+              "key": "app",
+              "value": "NotificationTemplaterService"
+            }
+          ],
+          "propertiesAsLabels": [
+            "app"
+          ]
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName"
+    ]
+  },
+  "valkey": "localhost:6379",
+  "serviceName": "NotificationTemplaterService",
+  "serviceVersion": "0.0.1",
+  "otlpEndpoint": "http://localhost:14318/v1/traces"
 }

--- a/src/Service/appsettings.json
+++ b/src/Service/appsettings.json
@@ -1,9 +1,28 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
+  "Serilog": {
+    "Using": [
+      "Serilog.Sinks.Console"
+    ],
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+        }
+      }
+    ],
+    "Enrich": [
+      "FromLogContext",
+      "WithMachineName"
+    ]
   },
-  "AllowedHosts": "*"
+  "valkey": "set in env variable",
+  "serviceName": "NotificationTemplaterService",
+  "serviceVersion": "set in env variable",
+  "otlpEndpoint": "set in env variable"
 }


### PR DESCRIPTION
This change introduces a Redis-backed template store, allowing users to save and retrieve templates by key. The existing template generation functionality is preserved, and new endpoints are added to save templates and generate content from saved templates. OpenTelemetry tracing and metrics are also integrated, along with a health check endpoint. The project is restructured to use partial classes for better organization.

## Summary by Sourcery

Implement a Redis/Valkey-backed template store with enhanced observability and modular configuration

New Features:
- Add endpoints to save and retrieve templates using a distributed cache
- Introduce ability to generate content from saved templates

Enhancements:
- Restructure project using partial classes for improved code organization
- Implement OpenTelemetry tracing and metrics integration

CI:
- Add health check and Prometheus metrics endpoints

Deployment:
- Configure application to use environment-based configuration for service name, version, and observability endpoints